### PR TITLE
Fix #4: Add HTTP probe

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,4 @@
 run:
-  issues-exit-code: 0
-  skip-dirs:
-    - protos
   skip-dirs-use-default: true
   timeout: 5m
 

--- a/probes.go
+++ b/probes.go
@@ -35,9 +35,10 @@ func GrpcProbe(conn GrpcStateReporter) Probe {
 // Pings a http endpoint for readiness. Called endpoint should return 2xx as status.
 //
 // Example:
-//		checker.AddReadinessProbe("my-http-service", health.HttpProbe("http://my-service:8080/ready"))
-func HttpProbe(endpoint string) Probe {
+//		checker.AddReadinessProbe("my-http-service", health.HTTPProbe("http://my-service:8080/ready"))
+func HTTPProbe(endpoint string) Probe {
 	return func() error {
+		// #nosec G107
 		resp, err := http.Get(endpoint)
 		if err != nil {
 			return fmt.Errorf("endpoint could not be reached: %v", err)

--- a/probes_test.go
+++ b/probes_test.go
@@ -49,28 +49,28 @@ func TestGrpcProbe_err(t *testing.T) {
 	assert.Error(t, probe())
 }
 
-func TestHttpProbe(t *testing.T) {
+func TestHTTPProbe(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 	}))
 	defer s.Close()
 
-	probe := HttpProbe(s.URL)
+	probe := HTTPProbe(s.URL)
 	assert.NoError(t, probe())
 }
 
-func TestHttpProbe_err(t *testing.T) {
+func TestHTTPProbe_err(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(503)
 	}))
 	defer s.Close()
 
-	probe := HttpProbe(s.URL)
+	probe := HTTPProbe(s.URL)
 	assert.Error(t, probe())
 }
 
-func TestHttpProbe_err_invalidUrl(t *testing.T) {
-	probe := HttpProbe("http://not-valid-endpoint.localhost/not-healthy")
+func TestHTTPProbe_err_invalidUrl(t *testing.T) {
+	probe := HTTPProbe("http://not-valid-endpoint.localhost/not-healthy")
 	assert.Error(t, probe())
 }
 


### PR DESCRIPTION
**Usage**
```go
checker.AddReadinessProbe("my-http-service", health.HttpProbe("http://my-service:8080/ready"))
```