### PR TITLE
Fix #5: Export AppendHealthEndpoints func

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The following table contains a set of common states / events and the expected he
 
 ## Implementation
 
-A service must implement an health endpoint to check if it is alive and ready. Both have to be served via `HTTP/1.1` under the same port (default: 8080) on **all** interfaces. The routes should be `/alive` and `/ready`. Those endpoints must not require any authentication or any additional header. Response should either be `200 OK` or `503 Service Unavailable` and a minimal JSON body.
+A service must implement a health endpoint to check if it is alive and ready. Both have to be served via `HTTP/1.1` under the same port (default: 8080) on **all** interfaces. The routes should be `/.well-known/alive` and `/.well-known/ready`. Those endpoints must not require any authentication or any additional header. Response should either be `200 OK` or `503 Service Unavailable` and a minimal JSON body.
 
 Both endpoints should be served independently and next to the main application on a different port.
 
@@ -59,7 +59,7 @@ Both endpoints should be served independently and next to the main application o
 
 The response for the liveliness probe should be a simple true or false.
 
-**`/alive`: success**
+**`/.well-known/alive`: success**
 
 ```http
 HTTP/1.1 200 OK
@@ -70,7 +70,7 @@ Content-Type: application/json
 }
 ```
 
-**`/alive`: failure**
+**`/.well-known/alive`: failure**
 
 ```http
 HTTP/1.1 503 Service Unavailable
@@ -85,7 +85,7 @@ Content-Type: application/json
 
 The response for the readiness probe should be a simple true or false. For debug purpose the failure response can contain a list of simple reasons, why a service is unhealthy. Detailed information should be reported via the metrics / telemetry endpoints.
 
-**`/ready`: success**
+**`/.well-known/ready`: success**
 
 ```http
 HTTP/1.1 200 OK
@@ -96,7 +96,7 @@ Content-Type: application/json
 }
 ```
 
-**`/ready`: failure**
+**`/.well-known/ready`: failure**
 
 ```http
 HTTP/1.1 503 Service Unavailable

--- a/README.md
+++ b/README.md
@@ -6,10 +6,28 @@ A dead simple health checker for GO applications
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/regiocom/healthchecker)](https://pkg.go.dev/github.com/regiocom/healthchecker) 
 
 ## Usage
+
+**Serve on same port with your application**
 ```go
 func main() {
-    health := &Checker{}
-    defer health.ServeHTTPBackground(":8080")()
+	checker := health.Checker{}
+
+	// This can be any http.ServerMux
+    checker.AppendHealthEndpoints(http.DefaultServeMux)
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("Hello World!"))
+	})
+
+	_ = http.ListenAndServe(":8080", http.DefaultServeMux)
+}
+```
+
+**Serve on separate port** 
+```go
+func main() {
+    checker := &health.Checker{}
+    defer checker.ServeHTTPBackground(":8080")()
 
     // Check an external gRPC Service
     cc, _ := grpc.Dial(...)

--- a/checker.go
+++ b/checker.go
@@ -89,12 +89,12 @@ func (h *Checker) Shutdown() error {
 func (h *Checker) serverMux() *http.ServeMux {
 	m := http.NewServeMux()
 
-	m.HandleFunc("/alive", func(w http.ResponseWriter, _ *http.Request) {
+	m.HandleFunc("/.well-known/alive", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"alive":true}`))
 	})
 
-	m.HandleFunc("/ready", func(w http.ResponseWriter, _ *http.Request) {
+	m.HandleFunc("/.well-known/ready", func(w http.ResponseWriter, _ *http.Request) {
 		ok, reasons := runProbes(h.readinessProbes)
 
 		resp := &readyResponse{

--- a/checker.go
+++ b/checker.go
@@ -86,9 +86,8 @@ func (h *Checker) Shutdown() error {
 	return h.server.Shutdown(ctx)
 }
 
-func (h *Checker) serverMux() *http.ServeMux {
-	m := http.NewServeMux()
-
+// Appends `/.well-known/alive` and `/.well-known/ready` endpoints to given server mux
+func (h *Checker) AppendHealthEndpoints(m *http.ServeMux) {
 	m.HandleFunc("/.well-known/alive", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"alive":true}`))
@@ -114,6 +113,12 @@ func (h *Checker) serverMux() *http.ServeMux {
 			log.Printf("failed to write health-check response: %v\n", err)
 		}
 	})
+}
+
+func (h *Checker) serverMux() *http.ServeMux {
+	m := http.NewServeMux()
+
+	h.AppendHealthEndpoints(m)
 
 	return m
 }

--- a/checker_test.go
+++ b/checker_test.go
@@ -15,7 +15,7 @@ func TestChecker_alive(t *testing.T) {
 	server := httptest.NewServer(checker.serverMux())
 	defer server.Close()
 
-	resp, err := http.Get(fmt.Sprintf("%v/alive", server.URL))
+	resp, err := http.Get(fmt.Sprintf("%v/.well-known/alive", server.URL))
 
 	assert.NoError(t, err)
 	assert.EqualValues(t, http.StatusOK, resp.StatusCode)
@@ -35,7 +35,7 @@ func TestChecker_AddHealthyProbe(t *testing.T) {
 	server := httptest.NewServer(checker.serverMux())
 	defer server.Close()
 
-	resp, err := http.Get(fmt.Sprintf("%v/ready", server.URL))
+	resp, err := http.Get(fmt.Sprintf("%v/.well-known/ready", server.URL))
 
 	assert.NoError(t, err)
 	assert.EqualValues(t, http.StatusOK, resp.StatusCode)
@@ -54,7 +54,7 @@ func TestChecker_AddHealthyProbe_unhealthy(t *testing.T) {
 	server := httptest.NewServer(checker.serverMux())
 	defer server.Close()
 
-	resp, err := http.Get(fmt.Sprintf("%v/ready", server.URL))
+	resp, err := http.Get(fmt.Sprintf("%v/.well-known/ready", server.URL))
 
 	assert.NoError(t, err)
 	assert.EqualValues(t, http.StatusServiceUnavailable, resp.StatusCode)

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,7 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.30.0 h1:M5a8xTlYTxwMn5ZFkwhRabsygDY5G8TYLyQDBxJNAxE=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.32.0 h1:zWTV+LMdc3kaiJMSTOFz2UgSBgx8RNQoTGiZu3fR9S0=
 google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=


### PR DESCRIPTION
This allows a us to serve the health endpoints on the same port as the existing application.

```go
func main() {
	checker := health.Checker{}

	// This can be any http.ServerMux
    checker.AppendHealthEndpoints(http.DefaultServeMux)

	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		_, _ = w.Write([]byte("Hello World!"))
	})

	_ = http.ListenAndServe(":8080", http.DefaultServeMux)
}
```